### PR TITLE
Change references to new location for this image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://badge.imagelayers.io/jakirkham/nanshe:latest.svg)](https://imagelayers.io/?images=jakirkham/nanshe:latest 'Get your own badge on imagelayers.io')
+[![](https://badge.imagelayers.io/nanshe/nanshe:latest.svg)](https://imagelayers.io/?images=nanshe/nanshe:latest 'Get your own badge on imagelayers.io')
 
 # Purpose
 
@@ -8,7 +8,7 @@ Provides the latest release of `nanshe` and dependencies installed in a supporte
 
 ## Automatic
 
-This repo is part of an automated build, which is hosted on Docker Hub ( <https://registry.hub.docker.com/u/jakirkham/nanshe> ). Changes added to this trigger an automatic rebuild and deploy the resulting image to Docker Hub. To download an existing image, one simply needs to run `docker pull jakirkham/nanshe`.
+This repo is part of an automated build, which is hosted on Docker Hub ( <https://registry.hub.docker.com/u/nanshe/nanshe> ). Changes added to this trigger an automatic rebuild and deploy the resulting image to Docker Hub. To download an existing image, one simply needs to run `docker pull nanshe/nanshe`.
 
 ## Manual
 
@@ -20,4 +20,4 @@ Only releases of `nanshe` are installed in this repo. `nanshe` is only released 
 
 # Usage
 
-Once an image is acquired either from one of the provided builds or manually, the image is designed to provide a preconfigured shell environment. Simply run `docker run -it <NAME>`. This will configure Grid Engine and a number of environment variables useful for maintaining it and starts up `bash`. At that point, any `nanshe` command can be run. In the case of an automated build, `<NAME>` is `jakirkham/nanshe`.
+Once an image is acquired either from one of the provided builds or manually, the image is designed to provide a preconfigured shell environment. Simply run `docker run -it <NAME>`. This will configure Grid Engine and a number of environment variables useful for maintaining it and starts up `bash`. At that point, any `nanshe` command can be run. In the case of an automated build, `<NAME>` is `nanshe/nanshe`.


### PR DESCRIPTION
Image is now built and placed here ( https://hub.docker.com/r/nanshe/nanshe/ ). As a result, we have updated links to its location.