### PR TITLE
Subscribe to the `nanshe` channel on <https://anaconda.org/>

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM jakirkham/centos_drmaa_conda:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
-RUN conda config --add channels jakirkham && \
+RUN conda config --add channels nanshe && \
     conda install -y --use-local -n root python=2.7 nanshe && \
     conda update -y --all && \
     rm -rf /opt/conda/conda-bld/work/* && \


### PR DESCRIPTION
Changes to subscribing to the organization channel on <https://anaconda.org/> to `nanshe`.