### PR TITLE
Dockerfile: Install and test `nanshe` in Python 2 and 3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,29 @@
 FROM jakirkham/centos_drmaa_conda:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
-RUN conda2 config --add channels nanshe && \
-    conda2 install -y --use-local -n root python=2.7 nomkl nanshe && \
-    conda2 update -y --all && \
-    rm -rf /opt/conda2/conda-bld/work/* && \
-    conda2 remove -y -n _build --all && \
-    conda2 remove -y -n _test --all && \
-    cp /opt/conda2/pkgs/nanshe-*.tar.bz2 / && \
-    conda2 clean -tipsy && \
-    mv /nanshe-*.tar.bz2 /opt/conda2/pkgs/
+RUN for PYTHON_VERSION in 2 3; do \
+        conda${PYTHON_VERSION} config --add channels nanshe && \
+        conda${PYTHON_VERSION} install -y --use-local -n root nomkl nanshe && \
+        conda${PYTHON_VERSION} update -y --all && \
+        rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
+        conda${PYTHON_VERSION} remove -y -n _build --all && \
+        conda${PYTHON_VERSION} remove -y -n _test --all && \
+        cp /opt/conda${PYTHON_VERSION}/pkgs/nanshe-*.tar.bz2 / && \
+        conda${PYTHON_VERSION} clean -tipsy && \
+        mv /nanshe-*.tar.bz2 /opt/conda${PYTHON_VERSION}/pkgs/ ; \
+    done
 
-RUN NANSHE_VERSION=`conda2 list -f nanshe 2>/dev/null | \
-                    tail -1 | \
-                    python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
-    curl -L "https://github.com/nanshe-org/nanshe/archive/v${NANSHE_VERSION}.tar.gz" | tar -xzf - && \
-    mv "/nanshe-${NANSHE_VERSION}" /nanshe && \
-    cd /nanshe && \
-    conda2 remove -y nanshe && \
-    /usr/share/docker/entrypoint.sh python2 setup.py test && \
-    conda2 install -y `find /opt/conda2/pkgs -name "nanshe-${NANSHE_VERSION}-*py27*.tar.bz2"` && \
-    conda2 clean -tipsy && \
-    cd / && \
-    rm -rf /nanshe
+RUN for PYTHON_VERSION in 2 3; do \
+        NANSHE_VERSION=`conda${PYTHON_VERSION} list -f nanshe 2>/dev/null | \
+                        tail -1 | \
+                        python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
+        curl -L "https://github.com/nanshe-org/nanshe/archive/v${NANSHE_VERSION}.tar.gz" | tar -xzf - && \
+        mv "/nanshe-${NANSHE_VERSION}" /nanshe && \
+        cd /nanshe && \
+        conda${PYTHON_VERSION} remove -y nanshe && \
+        /usr/share/docker/entrypoint.sh python${PYTHON_VERSION} setup.py test && \
+        conda${PYTHON_VERSION} install -y `find /opt/conda${PYTHON_VERSION}/pkgs -name "nanshe-${NANSHE_VERSION}-*.tar.bz2"` && \
+        conda${PYTHON_VERSION} clean -tipsy && \
+        cd / && \
+        rm -rf /nanshe ; \
+    done


### PR DESCRIPTION
Provides for working copies of `nanshe` in both environments. This allows a user to select the environment most appropriate for their use case.