### PR TITLE
Keep the package of the installed version of `nanshe`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ RUN for PYTHON_VERSION in 2 3; do \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
         conda${PYTHON_VERSION} remove -y -n _build --all && \
         conda${PYTHON_VERSION} remove -y -n _test --all && \
-        cp /opt/conda${PYTHON_VERSION}/pkgs/nanshe-*.tar.bz2 / && \
+        NANSHE_VERSION=`conda${PYTHON_VERSION} list -f nanshe 2>/dev/null | \
+                        tail -1 | \
+                        python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
+        cp /opt/conda${PYTHON_VERSION}/pkgs/nanshe-${NANSHE_VERSION}-*.tar.bz2 / && \
         conda${PYTHON_VERSION} clean -tipsy && \
-        mv /nanshe-*.tar.bz2 /opt/conda${PYTHON_VERSION}/pkgs/ ; \
+        mv /nanshe-${NANSHE_VERSION}-*.tar.bz2 /opt/conda${PYTHON_VERSION}/pkgs/ ; \
     done
 
 RUN for PYTHON_VERSION in 2 3; do \


### PR DESCRIPTION
Makes sure that only the correct package version of `nanshe` is kept. In some cases, we are seeing an issue where an older version of `nanshe` is installed despite newer ones being available. ( https://github.com/Anaconda-Server/support/issues/26 ). This works around that issue by checking the installed version of `nanshe` after all installations and subsequent updates, but right before clean up. Otherwise, everything works the same as before.
