### PR TITLE
Use conda-forge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM jakirkham/centos_drmaa_conda:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \
+        echo "hdf5 ==1.8.15.1" >> /opt/conda${PYTHON_VERSION}/conda-meta/pinned && \
         conda${PYTHON_VERSION} config --add channels conda-forge && \
         conda${PYTHON_VERSION} config --add channels nanshe && \
         conda${PYTHON_VERSION} install -y --use-local -n root nomkl nanshe && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM jakirkham/centos_drmaa_conda:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \
+        conda${PYTHON_VERSION} config --add channels conda-forge && \
         conda${PYTHON_VERSION} config --add channels nanshe && \
         conda${PYTHON_VERSION} install -y --use-local -n root nomkl nanshe && \
         conda${PYTHON_VERSION} update -y --all && \


### PR DESCRIPTION
Starts using conda-forge as the bulk of our dependencies are there at this point. This should substantially cut down our maintenance burden as we can share the load with others.

Also, this will avoid railing my laptop rebuilding everything when a new release of NumPy comes out. Currently we still need to build everything that is BLAS dependent though. In the future, this will also move to conda-forge, which should help out a bit.

~~We still need to de-dup the `nanshe` channel a bit, but this worked with the `jakirkham` channel just fine.~~ Done.

To get everything to work, we had to pin `hdf5` temporarily. This shouldn't be necessary in the future.