### PR TITLE
Drop `nomkl`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         conda config --add channels nanshe && \
-        conda install -qy --use-local -n root nomkl nanshe && \
+        conda install -qy --use-local -n root nanshe && \
         conda update -qy --all && \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                         tail -1 | \


### PR DESCRIPTION
Drop install of `nomkl` in the `Dockerfile` as it is no longer needed thanks to the recent `nanshe` release ( [`v0.1.0a54`]( https://github.com/nanshe-org/nanshe/releases/tag/v0.1.0a54 ) ) and [conda-forge]( http://conda-forge.github.io/ ).