### PR TITLE
Do not use conda's local index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         conda config --add channels nanshe && \
-        conda install -qy --use-local -n root nanshe && \
+        conda install -qy -n root nanshe && \
         conda update -qy --all && \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                         tail -1 | \


### PR DESCRIPTION
Appears that `conda` has some bug where if one tries to install from the local index it gets fouled up trying to serialize some traceback. As we don't really need to use the local index here, this stops using it. Was blocking our ability to build this image.

xref: https://github.com/conda/conda/issues/3985