### PR TITLE
Set OPENBLAS_NUM_THREADS to 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM jakirkham/centos_drmaa_conda:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
+ENV OPENBLAS_NUM_THREADS=1
+
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \


### PR DESCRIPTION
Make sure that OpenBLAS is restricted to 1 thread. As parallelism is handled by having multiple Python processes performing computations on different chunks, there is no need for this sort of parallelism to clash with lower level parallelism like OpenBLASes. After all the Python process parallelism allows the greatest degree of parallelism for the longest period of time whereas OpenBLAS parallelism is basically transient as it only exists for very specific operations in only some steps.