### PR TITLE
Add call to `entrypoint_2.sh`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         mv "/nanshe-${NANSHE_VERSION}" /nanshe && \
         cd /nanshe && \
         conda remove -qy nanshe && \
-        /usr/share/docker/entrypoint.sh python${PYTHON_VERSION} setup.py test && \
+        /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh python${PYTHON_VERSION} setup.py test && \
         conda install -qy `find ${INSTALL_CONDA_PATH}/pkgs -name "nanshe-${NANSHE_VERSION}-*.tar.bz2"` && \
         conda clean -tipsy && \
         cd / && \


### PR DESCRIPTION
Include a call to `entrypoint_2.sh` after `entrypoint.sh` as `entrypoint.sh` is now the entry point for the `jakirkham/centos_conda` image and `entrypoint_2.sh` is the entry point for the `jakirkham/centos_drmaa_conda` image. The latter being necessary for actually starting SGE.