### PR TITLE
Cleanup root's home directory (SGE version)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         SITE_PKGS_PATH=`python -c "import site; print(site.getsitepackages()[0])"` && \
         echo 'import os; import sys; os.environ["MPLCONFIGDIR"] = os.path.join(sys.prefix, "share", "matplotlib")' >> \
              "${SITE_PKGS_PATH}/sitecustomize.py" && \
+        python -c "import matplotlib; import matplotlib.pyplot" && \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                         tail -1 | \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         echo "tifffile 0.12.1" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
-        conda config --add channels nanshe && \
+        conda config --system --add channels nanshe && \
         conda install -qy -n root nanshe && \
         conda update -qy --all && \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN for PYTHON_VERSION in 2 3; do \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
         cp ${INSTALL_CONDA_PATH}/pkgs/nanshe-${NANSHE_VERSION}-*.tar.bz2 / && \
         conda clean -tipsy && \
+        rm -rf ~/.conda && \
         mv /nanshe-${NANSHE_VERSION}-*.tar.bz2 ${INSTALL_CONDA_PATH}/pkgs/ ; \
     done
 
@@ -31,6 +32,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh python${PYTHON_VERSION} setup.py test && \
         conda install -qy `find ${INSTALL_CONDA_PATH}/pkgs -name "nanshe-${NANSHE_VERSION}-*.tar.bz2"` && \
         conda clean -tipsy && \
+        rm -rf ~/.conda && \
         cd / && \
         rm -rf /nanshe ; \
     done

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda config --system --add channels nanshe && \
         conda install -qy -n root nanshe && \
         conda update -qy --all && \
+        SITE_PKGS_PATH=`python -c "import site; print(site.getsitepackages()[0])"` && \
+        echo 'import os; import sys; os.environ["MPLCONFIGDIR"] = os.path.join(sys.prefix, "share", "matplotlib")' >> \
+             "${SITE_PKGS_PATH}/sitecustomize.py" && \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                         tail -1 | \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe/pull/27 ) for SGE.

Does a bit of cleanup of `root`'s home directory by doing the following things.

1. Run `conda config` with `--system` (configures `conda` in the install).
2. Removes the empty `.conda` in `root`'s home.
3. Configures `MPLCONFIGDIR` in `sitecustomize.py` to be in the `conda` install.

As a bonus, triggers the font cache and config generation of `matplotlib` in the install layer (instead of implicitly generating it in the testing layer).