### PR TITLE
Make sure to deactivate `conda`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV OPENBLAS_NUM_THREADS=1
 
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . ${INSTALL_CONDA_PATH}/bin/activate root && \
+        . ${INSTALL_CONDA_PATH}/bin/activate && \
         echo "tifffile 0.12.1" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         conda config --system --add channels nanshe && \
         conda install -qy -n root nanshe && \
@@ -19,13 +19,14 @@ RUN for PYTHON_VERSION in 2 3; do \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
         cp ${INSTALL_CONDA_PATH}/pkgs/nanshe-${NANSHE_VERSION}-*.tar.bz2 / && \
         conda clean -tipsy && \
+        . ${INSTALL_CONDA_PATH}/bin/deactivate && \
         rm -rf ~/.conda && \
         mv /nanshe-${NANSHE_VERSION}-*.tar.bz2 ${INSTALL_CONDA_PATH}/pkgs/ ; \
     done
 
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . ${INSTALL_CONDA_PATH}/bin/activate root && \
+        . ${INSTALL_CONDA_PATH}/bin/activate && \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                         tail -1 | \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
@@ -36,6 +37,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         /usr/share/docker/entrypoint.sh python${PYTHON_VERSION} setup.py test && \
         conda install -qy `find ${INSTALL_CONDA_PATH}/pkgs -name "nanshe-${NANSHE_VERSION}-*.tar.bz2"` && \
         conda clean -tipsy && \
+        . ${INSTALL_CONDA_PATH}/bin/deactivate && \
         rm -rf ~/.conda && \
         cd / && \
         rm -rf /nanshe ; \


### PR DESCRIPTION
When looping through the `conda` installs, make sure to deactivate each one after we are done using that `conda` installation. Also drop `root` from `activate` as `root` is already assumed if no environment name is specified.