### PR TITLE
Unpin `tifffile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV OPENBLAS_NUM_THREADS=1
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate && \
-        echo "tifffile 0.12.1" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         conda config --system --add channels nanshe && \
         conda install -qy -n root nanshe && \
         conda update -qy --all && \


### PR DESCRIPTION
This reverts PR ( https://github.com/nanshe-org/docker_nanshe/pull/24 ).

Previously we needed to pin `tifffile` as version 0.13+ introduced breaking changes, which were not compatible with `nanshe` or `dask-imread` (the latter used in the workflow). As such, we pinned `tifffile` to a working version so that `nanshe` could behave as expected. However `tifffile` has made some changes that fix `dask-imread` and `nanshe` has also made changes to be more accommodating towards `tifffile`'s new behavior. As such, we can now unpin `tifffile` and use the latest version.