### PR TITLE
Support conda 4.4+ (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV OPENBLAS_NUM_THREADS=1
 
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . ${INSTALL_CONDA_PATH}/bin/activate && \
+        . "${INSTALL_CONDA_PATH}/etc/profile.d/conda.sh" && \
+        conda activate base && \
         conda config --system --add channels nanshe && \
         conda install -qy nanshe && \
         conda update -qy --all && \
@@ -18,14 +19,15 @@ RUN for PYTHON_VERSION in 2 3; do \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
         cp ${INSTALL_CONDA_PATH}/pkgs/nanshe-${NANSHE_VERSION}-*.tar.bz2 / && \
         conda clean -tipsy && \
-        . ${INSTALL_CONDA_PATH}/bin/deactivate && \
+        conda deactivate && \
         rm -rf ~/.conda && \
         mv /nanshe-${NANSHE_VERSION}-*.tar.bz2 ${INSTALL_CONDA_PATH}/pkgs/ ; \
     done
 
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . ${INSTALL_CONDA_PATH}/bin/activate && \
+        . "${INSTALL_CONDA_PATH}/etc/profile.d/conda.sh" && \
+        conda activate base && \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                         tail -1 | \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
@@ -36,7 +38,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh python${PYTHON_VERSION} setup.py test && \
         conda install -qy `find ${INSTALL_CONDA_PATH}/pkgs -name "nanshe-${NANSHE_VERSION}-*.tar.bz2"` && \
         conda clean -tipsy && \
-        . ${INSTALL_CONDA_PATH}/bin/deactivate && \
+        conda deactivate && \
         rm -rf ~/.conda && \
         cd / && \
         rm -rf /nanshe ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate && \
         conda config --system --add channels nanshe && \
-        conda install -qy -n root nanshe && \
+        conda install -qy nanshe && \
         conda update -qy --all && \
         SITE_PKGS_PATH=`python -c "import site; print(site.getsitepackages()[0])"` && \
         echo 'import os; import sys; os.environ["MPLCONFIGDIR"] = os.path.join(sys.prefix, "share", "matplotlib")' >> \


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe/pull/35 ) for SGE.

Refresh the activation/deactivation procedure to be compatible with `conda` 4.4+.