### PR TITLE
Skip moving around `nanshe` package (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,9 @@ RUN for PYTHON_VERSION in 2 3; do \
         NANSHE_VERSION=`conda list -f nanshe 2>/dev/null | \
                         tail -1 | \
                         python -c "from sys import stdin; print(stdin.read().split()[1])"` && \
-        cp ${INSTALL_CONDA_PATH}/pkgs/nanshe-${NANSHE_VERSION}-*.tar.bz2 / && \
         conda clean -tipsy && \
         conda deactivate && \
-        rm -rf ~/.conda && \
-        mv /nanshe-${NANSHE_VERSION}-*.tar.bz2 ${INSTALL_CONDA_PATH}/pkgs/ ; \
+        rm -rf ~/.conda ; \
     done
 
 RUN for PYTHON_VERSION in 2 3; do \
@@ -34,9 +32,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         curl -L "https://github.com/nanshe-org/nanshe/archive/v${NANSHE_VERSION}.tar.gz" | tar -xzf - && \
         mv "/nanshe-${NANSHE_VERSION}" /nanshe && \
         cd /nanshe && \
-        conda remove -qy nanshe && \
         /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh python${PYTHON_VERSION} setup.py test && \
-        conda install -qy `find ${INSTALL_CONDA_PATH}/pkgs -name "nanshe-${NANSHE_VERSION}-*.tar.bz2"` && \
         conda clean -tipsy && \
         conda deactivate && \
         rm -rf ~/.conda && \


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe/pull/37 ) for SGE.

As `conda` 4.4+ seems to be confused as to where the `nanshe` package is coming from and removing the `nanshe` package temporarily for testing has little utility as far as testing is concerned (since both the package and the downloaded source use the same code either way), simply keep the installed package around during testing. Should avoid these issues with `conda` recognizing `nanshe` was in the local index. Also should avoid some unnecessary noise in the Docker layers.